### PR TITLE
User preference fix - course view - mod_resource

### DIFF
--- a/classes/course_url.php
+++ b/classes/course_url.php
@@ -30,7 +30,7 @@ defined('MOODLE_INTERNAL') || die();
  * @copyright   2020 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class course_url extends \moodle_url  {
+class course_url extends \moodle_url {
 
     /**
      * Returns params for url.

--- a/lib.php
+++ b/lib.php
@@ -881,7 +881,11 @@ function format_hero_before_footer() {
     if ($contextlevel == CONTEXT_COURSE) {
         $targeturl = new \format_hero\course_url($rawurl);
     } else if ($contextlevel == CONTEXT_MODULE) {
-        $targeturl = new \format_hero\course_url($url);
+        if (strpos($rawurl->get_path(), 'mod/resource') !== false) {
+            $targeturl = new \format_hero\course_url($url, ['forceview' => 1]);
+        } else {
+            $targeturl = new \format_hero\course_url($url);
+        }
     }
 
     $path = $targeturl->get_path();


### PR DESCRIPTION
Hi @mattporritt,

I have added a fix for mod resource, did not encounter any with mod url - I added a 'forceview' param instead of a fallback to the section, if you wish to add a fallback on the section we can add this code

```
$cm = get_fast_modinfo($courseid)->get_cm($rawurl->get_param('id'));
$targeturl = new \format_hero\course_url('/course/view.php', ['id' => $courseid, 'section' => $cm->sectionnum]);
```

Cheers,

Marc