### PR TITLE
20 : Fix unknown named parameter

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -429,6 +429,12 @@ class format_hero extends core_courseformat\base {
                     'element_type' => 'editor',
                     'help' => 'sectiontext1',
                     'help_component' => 'format_hero',
+                    'element_attributes' => array(
+                        [
+                            'trusttext' => 0,
+                            'enable_filemanagement' => false
+                        ]
+                    )
                 ),
                 'sectionicon1' => array(
                     'label' => get_string('sectionicon1_label', 'format_hero'),
@@ -448,6 +454,12 @@ class format_hero extends core_courseformat\base {
                     'element_type' => 'editor',
                     'help' => 'sectiontext2',
                     'help_component' => 'format_hero',
+                    'element_attributes' => array(
+                        [
+                            'trusttext' => 0,
+                            'enable_filemanagement' => false
+                        ]
+                    )
                 ),
                 'sectionicon2' => array(
                     'label' => get_string('sectionicon2_label', 'format_hero'),
@@ -467,6 +479,12 @@ class format_hero extends core_courseformat\base {
                     'element_type' => 'editor',
                     'help' => 'sectiontext3',
                     'help_component' => 'format_hero',
+                    'element_attributes' => array(
+                        [
+                            'trusttext' => 0,
+                            'enable_filemanagement' => false
+                        ]
+                    )
                 ),
                 'sectionicon3' => array(
                     'label' => get_string('sectionicon3_label', 'format_hero'),
@@ -486,6 +504,12 @@ class format_hero extends core_courseformat\base {
                     'element_type' => 'editor',
                     'help' => 'sectiontext4',
                     'help_component' => 'format_hero',
+                    'element_attributes' => array(
+                        [
+                            'trusttext' => 0,
+                            'enable_filemanagement' => false
+                        ]
+                    )
                 ),
                 'sectionicon4' => array(
                     'label' => get_string('sectionicon4_label', 'format_hero'),
@@ -505,6 +529,12 @@ class format_hero extends core_courseformat\base {
                     'element_type' => 'editor',
                     'help' => 'sectiontext5',
                     'help_component' => 'format_hero',
+                    'element_attributes' => array(
+                        [
+                            'trusttext' => 0,
+                            'enable_filemanagement' => false
+                        ]
+                    )
                 ),
                 'sectionicon5' => array(
                     'label' => get_string('sectionicon5_label', 'format_hero'),


### PR DESCRIPTION
Closes https://github.com/catalyst/moodle-format_hero/issues/20

**Before:**

- when "Course formats" is "Hero"
- when requests to course/edit.php?category=0, getting error "Exception - Unknown named parameter $trusttext"

**Now:**

when requests to course/edit.php?category=0, no error